### PR TITLE
ifstreamにわたす前に文字コードを変える処理を追加

### DIFF
--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -79,9 +79,9 @@ bool open_model_files(const std::string &root_dir_path, const std::string librar
   const std::string decoder_model_path = root_dir_path + library_uuid + "/decoder_model.onnx";
   const std::string model_config_path = root_dir_path + library_uuid + "/model_config.json";
   std::ifstream variance_model_file(WPATH(variance_model_path), std::ios::binary),
-      embedder_model_file(embedder_model_path, std::ios::binary),
-      decoder_model_file(decoder_model_path, std::ios::binary),
-      model_config_file(model_config_path);
+      embedder_model_file(WPATH(embedder_model_path), std::ios::binary),
+      decoder_model_file(WPATH(decoder_model_path), std::ios::binary),
+      model_config_file(WPATH(model_config_path));
   if (!variance_model_file.is_open() || !embedder_model_file.is_open() || !decoder_model_file.is_open() || !model_config_file.is_open()) {
     error_message = FAILED_TO_OPEN_MODEL_ERR;
     return false;

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <unordered_set>
 #include <iostream>
-#include <codecvt>
 #include "nlohmann/json.hpp"
 
 #ifndef SHAREVOX_CORE_EXPORTS
@@ -31,6 +30,7 @@
 #define UNKNOWN_STYLE "Unknown style ID: "
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
+#include <Windows.h>
 #define WPATH(path) (utf8_to_wide(path).c_str())
 #else
 #define WPATH(path) (path)
@@ -60,10 +60,19 @@ struct Models {
   nlohmann::json model_config;
 };
 
+// ref: https://nekko1119.hatenablog.com/entry/2017/01/02/054629
+#if defined(_WIN32) && !defined(__CYGWIN__)
 std::wstring utf8_to_wide(std::string const& src) {
-  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-  return converter.from_bytes(src);
+  auto const dest_size = ::MultiByteToWideChar(CP_UTF8, 0U, src.data(), -1, nullptr, 0U);
+  std::vector<wchar_t> dest(dest_size, L'\0');
+  if (::MultiByteToWideChar(CP_UTF8, 0U, src.data(), -1, dest.data(), dest.size()) == 0) {
+    throw std::system_error{static_cast<int>(::GetLastError()), std::system_category()};
+  }
+  dest.resize(std::char_traits<wchar_t>::length(dest.data()));
+  dest.shrink_to_fit();
+  return std::wstring(dest.begin(), dest.end());
 }
+#endif
 
 // ref: https://qiita.com/aokomoriuta/items/949ef50bd21b15d10b76
 constexpr std::uint8_t gaussian_model_data[] = {


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

Windowsで、ユーザー名に日本語が含まれている場合にエラーになる問題を修正します。
文字コードを変換する関数を追加し、Windowsの場合は文字コードを変換してからifstreamにわたすようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

ref #1 

## その他
~~もしかしたら、open_jtalk側も修正が必要になるかもしれません。~~
~~以前、voicevox_coreのWindows c++ exampleを作ったときにも同様の問題が発生しました。~~
~~https://github.com/VOICEVOX/voicevox_core/pull/208~~
~~最新では修正されているはずだから、最新を使うようにすればいいだけ？~~
製品版のcore.dllを差し替えたら普通に起動しました。