### PR TITLE
[Rust] Clippyのコマンドを修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,28 +55,8 @@ jobs:
           python-version: "3.8"
       - uses: Swatinem/rust-cache@v2
       # FIXME: voicevox_core_python_apiがビルド不可となっている関係でclippyのチェックを不完全にしている
-      # - run: cargo clippy -vv --all-features --features onnxruntime/disable-sys-build-script --tests -- -D clippy::all -D warnings --no-deps
-      - run: |
-          cd crates/voicevox_core
-          cargo clippy -vv --tests -- -D clippy::all -D warnings --no-deps
-          cd -
-          cd crates/voicevox_core_c_api
-          cargo clippy -vv --tests -- -D clippy::all -D warnings --no-deps
-          cd -
-          cd crates/xtask
-          cargo clippy -vv --tests -- -D clippy::all -D warnings --no-deps
-          cd -
-      # - run: cargo clippy -vv --all-features --features onnxruntime/disable-sys-build-script -- -D clippy::all -D warnings --no-deps
-      - run: |
-          cd crates/voicevox_core
-          cargo clippy -vv -- -D clippy::all -D warnings --no-deps
-          cd -
-          cd crates/voicevox_core_c_api
-          cargo clippy -vv -- -D clippy::all -D warnings --no-deps
-          cd -
-          cd crates/xtask
-          cargo clippy -vv -- -D clippy::all -D warnings --no-deps
-          cd -
+      - run: cargo clippy -vv --all-features --features onnxruntime/disable-sys-build-script -p voicevox_core -p voicevox_core_c_api -p xtask --tests -- -D clippy::all -D warnings --no-deps
+      - run: cargo clippy -vv --all-features --features onnxruntime/disable-sys-build-script -p voicevox_core -p voicevox_core_c_api -p xtask -- -D clippy::all -D warnings --no-deps
       - run: cargo fmt -- --check
 
   rust-test:

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -386,7 +386,7 @@ impl InferenceCore {
                 .into_shape([1, accent_vector.len()])
                 .unwrap(),
         );
-        let mut speaker_id_array = NdArray::new(ndarray::arr1(&[model_speaker_id as i64]));
+        let mut speaker_id_array = NdArray::new(ndarray::arr1(&[model_speaker_id]));
 
         let input_tensors: Vec<&mut dyn AnyArray> = vec![
             &mut phoneme_vector_array,

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -70,14 +70,18 @@ pub extern "C" fn voicevox_make_default_initialize_options() -> VoicevoxInitiali
 /// 初期化する
 /// @param [in] options 初期化オプション
 /// @return 結果コード #VoicevoxResultCode
+///
+/// # Safety
+/// @param root_dir_path NUL-terminatedな文字列を指す、有効なポインタであること
+/// @param options open_jtalk_dict_dirがNUL-terminatedな文字列を指す、有効なポインタであること
 #[no_mangle]
-pub extern "C" fn voicevox_initialize(
+pub unsafe extern "C" fn voicevox_initialize(
     root_dir_path: *const c_char,
     options: VoicevoxInitializeOptions,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
-        let root_dir_path = unsafe { CStr::from_ptr(root_dir_path).to_str().unwrap().as_ref() };
-        let options = unsafe { options.try_into_options() }?;
+        let root_dir_path = CStr::from_ptr(root_dir_path).to_str().unwrap().as_ref();
+        let options = options.try_into_options()?;
         lock_internal().initialize(root_dir_path, options)?;
         Ok(())
     })())


### PR DESCRIPTION
## 内容

#4 に含まれるvoicevox_core_python_apiのClippy実行をしないようにした変更に対し、修正を行います。

該当箇所は実はPowerShell Coreで実行されているため、Bashでいう`-e`が効いていません。
またこのように簡潔に書けることから、`shell: bash`とするよりはこのように変更した方がよいと思いました。

## 関連 Issue

#4

## その他
