### PR TITLE
[Rust] エラーハンドリングを行う

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+
+[[package]]
 name = "futures"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,6 +2714,7 @@ dependencies = [
  "derive-getters",
  "derive-new",
  "flate2",
+ "fs-err",
  "heck",
  "once_cell",
  "onnxruntime",

--- a/crates/voicevox_core/Cargo.toml
+++ b/crates/voicevox_core/Cargo.toml
@@ -21,6 +21,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 open_jtalk = { git = "https://github.com/VOICEVOX/open_jtalk-rs.git", rev="9edab53f0bfa877dbb37224d17fd0f3efbe32abd" }
 regex = "1.6.0"
+fs-err = "2.9.0"
 
 [dev-dependencies]
 rstest = "0.15.0"

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
     InvalidSpeakerId { speaker_id: u32 },
 
     #[error(
-        "{}: {library_uuid:}",
+        "{}: {library_uuid:?}",
         base_error_message(VOICEVOX_RESULT_INVALID_LIBRARY_UUID_ERROR)
     )]
     InvalidLibraryUuid { library_uuid: String },

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -45,10 +45,10 @@ pub enum Error {
     InvalidSpeakerId { speaker_id: u32 },
 
     #[error(
-        "{}: {library_uuid:?}",
-        base_error_message(VOICEVOX_RESULT_INVALID_LIBRARY_UUID_ERROR)
+        "{}: {model_index}",
+        base_error_message(VOICEVOX_RESULT_INVALID_MODEL_INDEX_ERROR)
     )]
-    InvalidLibraryUuid { library_uuid: String },
+    InvalidModelIndex { model_index: usize },
 
     #[error("{}", base_error_message(VOICEVOX_RESULT_INFERENCE_ERROR))]
     InferenceFailed,
@@ -62,12 +62,12 @@ pub enum Error {
     #[error("{},{0}", base_error_message(VOICEVOX_RESULT_PARSE_KANA_ERROR))]
     ParseKana(#[from] KanaParseError),
 
-    #[error("{},{0}", base_error_message(VOICEVOX_RESULT_LOAD_LIBRARIES_ERROR))]
+    #[error("{},{0}", base_error_message(SHAREVOX_RESULT_LOAD_LIBRARIES_ERROR))]
     LoadLibraries(#[source] anyhow::Error),
 
     #[error(
         "{}({}),{cause}",
-        base_error_message(VOICEVOX_RESULT_LOAD_MODEL_CONFIG_ERROR),
+        base_error_message(SHAREVOX_RESULT_LOAD_MODEL_CONFIG_ERROR),
         path.display()
     )]
     LoadModelConfig {
@@ -75,6 +75,12 @@ pub enum Error {
         #[source]
         cause: anyhow::Error,
     },
+
+    #[error(
+        "{}: {library_uuid:?}",
+        base_error_message(SHAREVOX_RESULT_INVALID_LIBRARY_UUID_ERROR)
+    )]
+    InvalidLibraryUuid { library_uuid: String },
 }
 
 impl PartialEq for Error {
@@ -99,15 +105,23 @@ impl PartialEq for Error {
                 },
             ) => speaker_id1 == speaker_id2,
             (
-                Self::InvalidLibraryUuid {
-                    library_uuid: model_index1,
+                Self::InvalidModelIndex {
+                    model_index: model_index1,
                 },
-                Self::InvalidLibraryUuid {
-                    library_uuid: model_index2,
+                Self::InvalidModelIndex {
+                    model_index: model_index2,
                 },
             ) => model_index1 == model_index2,
             (Self::ExtractFullContextLabel(e1), Self::ExtractFullContextLabel(e2)) => e1 == e2,
             (Self::ParseKana(e1), Self::ParseKana(e2)) => e1 == e2,
+            (
+                Self::InvalidLibraryUuid {
+                    library_uuid: library_uuid1,
+                },
+                Self::InvalidLibraryUuid {
+                    library_uuid: library_uuid2,
+                },
+            ) => library_uuid1 == library_uuid2,
             (
                 Self::LoadModelConfig {
                     path: path1,

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -610,7 +610,7 @@ pub const fn error_result_to_message(result_code: VoicevoxResultCode) -> &'stati
         VOICEVOX_RESULT_OK => "エラーが発生しませんでした\0",
         VOICEVOX_RESULT_UNINITIALIZED_STATUS_ERROR => "Statusが初期化されていません\0",
         VOICEVOX_RESULT_INVALID_SPEAKER_ID_ERROR => "無効なspeaker_idです\0",
-        VOICEVOX_RESULT_INVALID_LIBRARY_UUID_ERROR => "無効なlibrary_uuidです\0",
+        VOICEVOX_RESULT_INVALID_MODEL_INDEX_ERROR => "無効なmodel_indexです\0",
         VOICEVOX_RESULT_INFERENCE_ERROR => "推論に失敗しました\0",
         VOICEVOX_RESULT_EXTRACT_FULL_CONTEXT_LABEL_ERROR => {
             "入力テキストからのフルコンテキストラベル抽出に失敗しました\0"
@@ -620,8 +620,9 @@ pub const fn error_result_to_message(result_code: VoicevoxResultCode) -> &'stati
             "入力テキストをAquesTalkライクな読み仮名としてパースすることに失敗しました\0"
         }
         VOICEVOX_RESULT_INVALID_AUDIO_QUERY_ERROR => "無効なaudio_queryです\0",
-        VOICEVOX_RESULT_LOAD_LIBRARIES_ERROR => "libraries.jsonの読み込みに失敗しました\0",
-        VOICEVOX_RESULT_LOAD_MODEL_CONFIG_ERROR => "model_config.jsonの読み込みに失敗しました\0",
+        SHAREVOX_RESULT_LOAD_LIBRARIES_ERROR => "libraries.jsonの読み込みに失敗しました\0",
+        SHAREVOX_RESULT_LOAD_MODEL_CONFIG_ERROR => "model_config.jsonの読み込みに失敗しました\0",
+        SHAREVOX_RESULT_INVALID_LIBRARY_UUID_ERROR => "無効なlibrary_uuidです\0",
     }
 }
 

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -284,7 +284,7 @@ impl InferenceCore {
             let mut status = Status::new(root_dir_path, use_gpu, cpu_num_threads);
 
             status.load_metas()?;
-            status.load();
+            status.load()?;
 
             if load_all_models {
                 for library_uuid in status.usable_libraries.clone() {
@@ -610,7 +610,7 @@ pub const fn error_result_to_message(result_code: VoicevoxResultCode) -> &'stati
         VOICEVOX_RESULT_OK => "エラーが発生しませんでした\0",
         VOICEVOX_RESULT_UNINITIALIZED_STATUS_ERROR => "Statusが初期化されていません\0",
         VOICEVOX_RESULT_INVALID_SPEAKER_ID_ERROR => "無効なspeaker_idです\0",
-        VOICEVOX_RESULT_INVALID_MODEL_INDEX_ERROR => "無効なmodel_indexです\0",
+        VOICEVOX_RESULT_INVALID_LIBRARY_UUID_ERROR => "無効なlibrary_uuidです\0",
         VOICEVOX_RESULT_INFERENCE_ERROR => "推論に失敗しました\0",
         VOICEVOX_RESULT_EXTRACT_FULL_CONTEXT_LABEL_ERROR => {
             "入力テキストからのフルコンテキストラベル抽出に失敗しました\0"
@@ -620,6 +620,8 @@ pub const fn error_result_to_message(result_code: VoicevoxResultCode) -> &'stati
             "入力テキストをAquesTalkライクな読み仮名としてパースすることに失敗しました\0"
         }
         VOICEVOX_RESULT_INVALID_AUDIO_QUERY_ERROR => "無効なaudio_queryです\0",
+        VOICEVOX_RESULT_LOAD_LIBRARIES_ERROR => "libraries.jsonの読み込みに失敗しました\0",
+        VOICEVOX_RESULT_LOAD_MODEL_CONFIG_ERROR => "model_config.jsonの読み込みに失敗しました\0",
     }
 }
 

--- a/crates/voicevox_core/src/result_code.rs
+++ b/crates/voicevox_core/src/result_code.rs
@@ -21,8 +21,8 @@ pub enum VoicevoxResultCode {
     VOICEVOX_RESULT_UNINITIALIZED_STATUS_ERROR = 6,
     /// 無効なspeaker_idが指定された
     VOICEVOX_RESULT_INVALID_SPEAKER_ID_ERROR = 7,
-    /// 無効なmodel_indexが指定された
-    VOICEVOX_RESULT_INVALID_MODEL_INDEX_ERROR = 8,
+    /// 無効なlibrary_uuidが指定された
+    VOICEVOX_RESULT_INVALID_LIBRARY_UUID_ERROR = 8,
     /// 推論に失敗した
     VOICEVOX_RESULT_INFERENCE_ERROR = 9,
     /// コンテキストラベル出力に失敗した
@@ -33,4 +33,8 @@ pub enum VoicevoxResultCode {
     VOICEVOX_RESULT_PARSE_KANA_ERROR = 12,
     /// 無効なAudioQuery
     VOICEVOX_RESULT_INVALID_AUDIO_QUERY_ERROR = 13,
+    /// libraries.jsonの読み込みに失敗した
+    VOICEVOX_RESULT_LOAD_LIBRARIES_ERROR = 14,
+    /// model_config.jsonの読み込みに失敗した
+    VOICEVOX_RESULT_LOAD_MODEL_CONFIG_ERROR = 15,
 }

--- a/crates/voicevox_core/src/result_code.rs
+++ b/crates/voicevox_core/src/result_code.rs
@@ -21,8 +21,8 @@ pub enum VoicevoxResultCode {
     VOICEVOX_RESULT_UNINITIALIZED_STATUS_ERROR = 6,
     /// 無効なspeaker_idが指定された
     VOICEVOX_RESULT_INVALID_SPEAKER_ID_ERROR = 7,
-    /// 無効なlibrary_uuidが指定された
-    VOICEVOX_RESULT_INVALID_LIBRARY_UUID_ERROR = 8,
+    /// 無効なmodel_indexが指定された
+    VOICEVOX_RESULT_INVALID_MODEL_INDEX_ERROR = 8,
     /// 推論に失敗した
     VOICEVOX_RESULT_INFERENCE_ERROR = 9,
     /// コンテキストラベル出力に失敗した
@@ -34,7 +34,9 @@ pub enum VoicevoxResultCode {
     /// 無効なAudioQuery
     VOICEVOX_RESULT_INVALID_AUDIO_QUERY_ERROR = 13,
     /// libraries.jsonの読み込みに失敗した
-    VOICEVOX_RESULT_LOAD_LIBRARIES_ERROR = 14,
+    SHAREVOX_RESULT_LOAD_LIBRARIES_ERROR = 100,
     /// model_config.jsonの読み込みに失敗した
-    VOICEVOX_RESULT_LOAD_MODEL_CONFIG_ERROR = 15,
+    SHAREVOX_RESULT_LOAD_MODEL_CONFIG_ERROR = 101,
+    /// 無効なlibrary_uuidが指定された
+    SHAREVOX_RESULT_INVALID_LIBRARY_UUID_ERROR = 102,
 }

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -19,8 +19,11 @@ pub extern "C" fn initialize(
     cpu_num_threads: c_int,
     load_all_models: bool,
 ) -> bool {
+    let Ok(root_dir_path) = unsafe { CStr::from_ptr(root_dir_path) }.to_str() else {
+        return false;
+    };
     let result = lock_internal().initialize(
-        unsafe { CStr::from_ptr(root_dir_path).to_str().unwrap().as_ref() },
+        root_dir_path.as_ref(),
         voicevox_core::InitializeOptions {
             acceleration_mode: if use_gpu {
                 voicevox_core::AccelerationMode::Gpu

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -28,14 +28,15 @@ pub(crate) fn into_result_code_with_error(result: CApiResult<()>) -> VoicevoxRes
             Err(RustApi(GetSupportedDevices(_))) => VOICEVOX_RESULT_GET_SUPPORTED_DEVICES_ERROR,
             Err(RustApi(UninitializedStatus)) => VOICEVOX_RESULT_UNINITIALIZED_STATUS_ERROR,
             Err(RustApi(InvalidSpeakerId { .. })) => VOICEVOX_RESULT_INVALID_SPEAKER_ID_ERROR,
-            Err(RustApi(InvalidLibraryUuid { .. })) => VOICEVOX_RESULT_INVALID_LIBRARY_UUID_ERROR,
+            Err(RustApi(InvalidModelIndex { .. })) => VOICEVOX_RESULT_INVALID_MODEL_INDEX_ERROR,
             Err(RustApi(InferenceFailed)) => VOICEVOX_RESULT_INFERENCE_ERROR,
             Err(RustApi(ExtractFullContextLabel(_))) => {
                 VOICEVOX_RESULT_EXTRACT_FULL_CONTEXT_LABEL_ERROR
             }
             Err(RustApi(ParseKana(_))) => VOICEVOX_RESULT_PARSE_KANA_ERROR,
-            Err(RustApi(LoadLibraries(_))) => VOICEVOX_RESULT_LOAD_LIBRARIES_ERROR,
-            Err(RustApi(LoadModelConfig { .. })) => VOICEVOX_RESULT_LOAD_MODEL_CONFIG_ERROR,
+            Err(RustApi(LoadLibraries(_))) => SHAREVOX_RESULT_LOAD_LIBRARIES_ERROR,
+            Err(RustApi(LoadModelConfig { .. })) => SHAREVOX_RESULT_LOAD_MODEL_CONFIG_ERROR,
+            Err(RustApi(InvalidLibraryUuid { .. })) => SHAREVOX_RESULT_INVALID_LIBRARY_UUID_ERROR,
             Err(InvalidUtf8Input) => VOICEVOX_RESULT_INVALID_UTF8_INPUT_ERROR,
             Err(InvalidAudioQuery(_)) => VOICEVOX_RESULT_INVALID_AUDIO_QUERY_ERROR,
         }

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -28,12 +28,14 @@ pub(crate) fn into_result_code_with_error(result: CApiResult<()>) -> VoicevoxRes
             Err(RustApi(GetSupportedDevices(_))) => VOICEVOX_RESULT_GET_SUPPORTED_DEVICES_ERROR,
             Err(RustApi(UninitializedStatus)) => VOICEVOX_RESULT_UNINITIALIZED_STATUS_ERROR,
             Err(RustApi(InvalidSpeakerId { .. })) => VOICEVOX_RESULT_INVALID_SPEAKER_ID_ERROR,
-            Err(RustApi(InvalidModelIndex { .. })) => VOICEVOX_RESULT_INVALID_MODEL_INDEX_ERROR,
+            Err(RustApi(InvalidLibraryUuid { .. })) => VOICEVOX_RESULT_INVALID_LIBRARY_UUID_ERROR,
             Err(RustApi(InferenceFailed)) => VOICEVOX_RESULT_INFERENCE_ERROR,
             Err(RustApi(ExtractFullContextLabel(_))) => {
                 VOICEVOX_RESULT_EXTRACT_FULL_CONTEXT_LABEL_ERROR
             }
             Err(RustApi(ParseKana(_))) => VOICEVOX_RESULT_PARSE_KANA_ERROR,
+            Err(RustApi(LoadLibraries(_))) => VOICEVOX_RESULT_LOAD_LIBRARIES_ERROR,
+            Err(RustApi(LoadModelConfig { .. })) => VOICEVOX_RESULT_LOAD_MODEL_CONFIG_ERROR,
             Err(InvalidUtf8Input) => VOICEVOX_RESULT_INVALID_UTF8_INPUT_ERROR,
             Err(InvalidAudioQuery(_)) => VOICEVOX_RESULT_INVALID_AUDIO_QUERY_ERROR,
         }

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -76,7 +76,7 @@ pub extern "C" fn voicevox_initialize(
     options: VoicevoxInitializeOptions,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
-        let root_dir_path = unsafe { CStr::from_ptr(root_dir_path).to_str().unwrap().as_ref() };
+        let root_dir_path = ensure_utf8(unsafe { CStr::from_ptr(root_dir_path) })?.as_ref();
         let options = unsafe { options.try_into_options() }?;
         lock_internal().initialize(root_dir_path, options)?;
         Ok(())


### PR DESCRIPTION
## 内容

エラーハンドリングについてのFIXMEを剥がしました。

また以下の`Error`をざっくりと追加しました。

- `InvalidModelIndex` (` = 8`) → `InvalidLibraryUuid` (` = 8`)
- `LoadLibraries` (`= 14`)を追加
- `LoadModelConfig` (`= 15`)を追加

## 関連 Issue

#3

## その他
