### PR TITLE
[Rust] PartialEqにInvalidLengthRegulatorエラーを追加

### DIFF
--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -138,6 +138,14 @@ impl PartialEq for Error {
                     cause: cause2,
                 },
             ) => (path1, cause1.to_string()) == (path2, cause2.to_string()),
+            (
+                Self::InvalidLengthRegulator {
+                    length_regulator_type: length_regulator_type1,
+                },
+                Self::InvalidLengthRegulator {
+                    length_regulator_type: length_regulator_type2,
+                },
+            ) => length_regulator_type1 == length_regulator_type2,
             _ => false,
         }
     }


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り、使われてないみたいだけど、書き忘れていたので追記

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #3 
