### PR TITLE
[Rust] 関数の名前を変更

### DIFF
--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -128,7 +128,7 @@ impl SynthesisEngine {
     ) -> Result<(Vec<AccentPhraseModel>, Vec<f32>)> {
         let (_, phoneme_id_list, accent_id_list) = SynthesisEngine::initial_process(accent_phrases);
 
-        let (pitches, phoneme_length) = self.inference_core_mut().variance_forward(
+        let (pitches, phoneme_length) = self.inference_core_mut().predict_pitch_and_duration(
             &phoneme_id_list,
             &accent_id_list,
             speaker_id,
@@ -194,7 +194,7 @@ impl SynthesisEngine {
         } else {
             pitches = self
                 .inference_core_mut()
-                .variance_forward(&phoneme_id_list, &accent_id_list, speaker_id)?
+                .predict_pitch_and_duration(&phoneme_id_list, &accent_id_list, speaker_id)?
                 .0;
         }
 
@@ -312,7 +312,7 @@ impl SynthesisEngine {
         }
 
         self.inference_core_mut()
-            .decode_forward(&phoneme_id_list, &pitches, &durations, speaker_id)
+            .decode(&phoneme_id_list, &pitches, &durations, speaker_id)
     }
 
     pub fn synthesis_wave_format(

--- a/crates/voicevox_core/src/error.rs
+++ b/crates/voicevox_core/src/error.rs
@@ -87,6 +87,12 @@ pub enum Error {
         base_error_message(SHAREVOX_RESULT_INVALID_LENGTH_REGULATOR_ERROR)
     )]
     InvalidLengthRegulator { length_regulator_type: String },
+
+    #[error(
+        "{}: {synthesis_system:?}",
+        base_error_message(SHAREVOX_RESULT_INVALID_SYNTHESIS_SYSTEM_ERROR)
+    )]
+    InvalidSynthesisSystem { synthesis_system: String },
 }
 
 impl PartialEq for Error {
@@ -146,6 +152,14 @@ impl PartialEq for Error {
                     length_regulator_type: length_regulator_type2,
                 },
             ) => length_regulator_type1 == length_regulator_type2,
+            (
+                Self::InvalidSynthesisSystem {
+                    synthesis_system: synthesis_system1,
+                },
+                Self::InvalidSynthesisSystem {
+                    synthesis_system: synthesis_system2,
+                },
+            ) => synthesis_system1 == synthesis_system2,
             _ => false,
         }
     }

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -108,27 +108,27 @@ impl VoicevoxCore {
         &SUPPORTED_DEVICES_CSTRING
     }
 
-    pub fn variance_forward(
+    pub fn predict_pitch_and_duration(
         &mut self,
         phoneme_vector: &[i64],
         accent_vector: &[i64],
         speaker_id: u32,
     ) -> Result<(Vec<f32>, Vec<f32>)> {
-        self.synthesis_engine.inference_core_mut().variance_forward(
+        self.synthesis_engine.inference_core_mut().predict_pitch_and_duration(
             phoneme_vector,
             accent_vector,
             speaker_id,
         )
     }
 
-    pub fn decode_forward(
+    pub fn decode(
         &mut self,
         phoneme_vector: &[i64],
         pitch_vector: &[f32],
         duration_vector: &[f32],
         speaker_id: u32,
     ) -> Result<Vec<f32>> {
-        self.synthesis_engine.inference_core_mut().decode_forward(
+        self.synthesis_engine.inference_core_mut().decode(
             phoneme_vector,
             pitch_vector,
             duration_vector,
@@ -323,7 +323,7 @@ impl InferenceCore {
         }
     }
 
-    pub fn variance_forward(
+    pub fn predict_pitch_and_duration(
         &mut self,
         phoneme_vector: &[i64],
         accent_vector: &[i64],
@@ -375,7 +375,7 @@ impl InferenceCore {
         status.variance_session_run(&library_uuid, input_tensors)
     }
 
-    pub fn decode_forward(
+    pub fn decode(
         &mut self,
         phoneme_vector: &[i64],
         pitch_vector: &[f32],
@@ -756,7 +756,7 @@ mod tests {
     // }
 
     #[rstest]
-    fn variance_forward_works() {
+    fn predict_pitch_and_duration_works() {
         let internal = VoicevoxCore::new_with_mutex();
         internal
             .lock()
@@ -781,7 +781,7 @@ mod tests {
         let result = internal
             .lock()
             .unwrap()
-            .variance_forward(&phoneme_vector, &accent_vector, 0);
+            .predict_pitch_and_duration(&phoneme_vector, &accent_vector, 0);
 
         assert!(result.is_ok(), "{:?}", result);
 
@@ -827,7 +827,7 @@ mod tests {
     // }
 
     #[rstest]
-    fn decode_forward_works() {
+    fn decode_works() {
         let internal = VoicevoxCore::new_with_mutex();
         internal
             .lock()
@@ -850,7 +850,7 @@ mod tests {
         let pitch_vector = vec![5.5; phoneme_vector.len()];
         let duration_vector = vec![0.1; phoneme_vector.len()];
 
-        let result = internal.lock().unwrap().decode_forward(
+        let result = internal.lock().unwrap().decode(
             &phoneme_vector,
             &pitch_vector,
             &duration_vector,

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -433,11 +433,22 @@ impl InferenceCore {
 
         let length_regulated_vector: Vec<f32>;
         if length_regulator_type == "normal" {
-            length_regulated_vector =
-                status.length_regulator(phoneme_vector.len(), embedded_vector, duration_vector);
+            length_regulated_vector = status.length_regulator(
+                phoneme_vector.len(),
+                embedded_vector,
+                duration_vector,
+                None,
+                None,
+                None,
+            );
         } else if length_regulator_type == "gaussian" {
-            length_regulated_vector =
-                status.gaussian_upsampling(phoneme_vector.len(), embedded_vector, duration_vector);
+            length_regulated_vector = status.gaussian_upsampling(
+                phoneme_vector.len(),
+                embedded_vector,
+                duration_vector,
+                None,
+                None,
+            );
         } else {
             return Err(Error::InvalidLengthRegulator {
                 length_regulator_type: length_regulator_type.to_owned(),

--- a/crates/voicevox_core/src/result_code.rs
+++ b/crates/voicevox_core/src/result_code.rs
@@ -41,4 +41,6 @@ pub enum VoicevoxResultCode {
     SHAREVOX_RESULT_INVALID_LIBRARY_UUID_ERROR = 102,
     /// model_config.jsonのlength_regulatorが無効
     SHAREVOX_RESULT_INVALID_LENGTH_REGULATOR_ERROR = 103,
+    /// model_config.jsonのsynthesis_systemが無効
+    SHAREVOX_RESULT_INVALID_SYNTHESIS_SYSTEM_ERROR = 104,
 }

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -386,18 +386,23 @@ impl Status {
         length: usize,
         embedded_vector: &[f32],
         durations: &[f32],
+        regulation_base: Option<f32>,
+        dim: Option<usize>,
+        upsample_rate: Option<usize>,
     ) -> Vec<f32> {
         let mut length_regulated_vector = Vec::new();
         for i in 0..length {
             // numpy/pythonのroundと挙動を合わせるため、round_ties_even_を用いている
-            let regulation_size = ((durations[i] * 93.75).round_ties_even_() as usize) * 2; // 24000 / 256 = 93.75
+            let regulation_size = ((durations[i] * regulation_base.unwrap_or(93.75))
+                .round_ties_even_() as usize)
+                * upsample_rate.unwrap_or(2); // 24000 / 256 = 93.75
             let start = length_regulated_vector.len();
-            let expand_size = regulation_size * Status::HIDDEN_SIZE;
+            let dim = dim.unwrap_or(Status::HIDDEN_SIZE);
+            let expand_size = regulation_size * dim;
             length_regulated_vector.resize_with(start + expand_size, Default::default);
-            for j in (0..expand_size).step_by(Status::HIDDEN_SIZE) {
-                for k in 0..Status::HIDDEN_SIZE {
-                    length_regulated_vector[start + j + k] =
-                        embedded_vector[i * Status::HIDDEN_SIZE + k];
+            for j in (0..expand_size).step_by(dim) {
+                for k in 0..dim {
+                    length_regulated_vector[start + j + k] = embedded_vector[i * dim + k];
                 }
             }
         }
@@ -409,11 +414,15 @@ impl Status {
         length: usize,
         embedded_vector: &[f32],
         durations: &[f32],
+        regulation_base: Option<f32>,
+        upsample_rate: Option<usize>,
     ) -> Vec<f32> {
         let mut int_durations = vec![0; length];
         for i in 0..length {
             // numpy/pythonのroundと挙動を合わせるため、round_ties_even_を用いている
-            let regulation_size = ((durations[i] * 93.75).round_ties_even_() as usize) * 2; // 24000 / 256 = 93.75
+            let regulation_size = ((durations[i] * regulation_base.unwrap_or(93.75))
+                .round_ties_even_() as usize)
+                * upsample_rate.unwrap_or(2); // 24000 / 256 = 93.75
             int_durations[i] = regulation_size as i64;
         }
 
@@ -557,10 +566,18 @@ mod tests {
         embedded_vector.append(&mut vec![1.; 192]);
         // round(0.11 * 93.75) = 10, round(0.21 * 93.75) = 20
         let durations = vec![0.11, 0.21];
-        let result = status.length_regulator(2, &embedded_vector, &durations);
-        let mut expected = vec![0.; 192 * 10 * 2];
+        let result = status.length_regulator(2, &embedded_vector, &durations, None, None, None);
         assert_eq!(result.len(), 192 * 30 * 2);
+        let mut expected = vec![0.; 192 * 10 * 2];
         expected.append(&mut vec![1.; 192 * 20 * 2]);
+        assert_eq!(result, expected);
+
+        let pitch_vector = vec![5.5, 6.0];
+        let durations = vec![0.1, 0.2];
+        let result = status.length_regulator(2, &pitch_vector, &durations, Some(100.), Some(1), Some(1));
+        assert_eq!(result.len(), 1 * 30 * 1);
+        let mut expected = vec![5.5; 10];
+        expected.append(&mut vec![6.0; 20]);
         assert_eq!(result, expected);
     }
 
@@ -577,7 +594,7 @@ mod tests {
         embedded_vector.append(&mut vec![1.; 192]);
         // round(0.11 * 93.75) = 10, round(0.21 * 93.75) = 20
         let durations = vec![0.11, 0.21];
-        let result = status.gaussian_upsampling(2, &embedded_vector, &durations);
+        let result = status.gaussian_upsampling(2, &embedded_vector, &durations, None, None);
         assert_eq!(result.len(), 192 * 30 * 2);
     }
 }

--- a/crates/voicevox_core/src/status.rs
+++ b/crates/voicevox_core/src/status.rs
@@ -118,6 +118,7 @@ impl SupportedDevices {
 pub struct ModelConfig {
     pub length_regulator: String,
     pub start_id: usize,
+    pub synthesis_system: Option<String>,
 }
 
 fn open_metas(root_dir_path: &Path, library_uuid: &str) -> Result<Vec<Meta>> {
@@ -574,7 +575,8 @@ mod tests {
 
         let pitch_vector = vec![5.5, 6.0];
         let durations = vec![0.1, 0.2];
-        let result = status.length_regulator(2, &pitch_vector, &durations, Some(100.), Some(1), Some(1));
+        let result =
+            status.length_regulator(2, &pitch_vector, &durations, Some(100.), Some(1), Some(1));
         assert_eq!(result.len(), 1 * 30 * 1);
         let mut expected = vec![5.5; 10];
         expected.append(&mut vec![6.0; 20]);

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -88,7 +88,7 @@ pub extern "C" fn variance_forward(
     pitch_output: *mut f32,
     duration_output: *mut f32,
 ) -> bool {
-    let result = lock_internal().variance_forward(
+    let result = lock_internal().predict_pitch_and_duration(
         unsafe { std::slice::from_raw_parts_mut(phoneme_list, length as usize) },
         unsafe { std::slice::from_raw_parts_mut(accent_list, length as usize) },
         unsafe { *speaker_id as u32 },
@@ -120,7 +120,7 @@ pub extern "C" fn decode_forward(
     output: *mut f32,
 ) -> bool {
     let length = length as usize;
-    let result = lock_internal().decode_forward(
+    let result = lock_internal().decode(
         unsafe { std::slice::from_raw_parts_mut(phonemes, length) },
         unsafe { std::slice::from_raw_parts_mut(pitches, length) },
         unsafe { std::slice::from_raw_parts_mut(durations, length) },

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -107,21 +107,21 @@ pub(crate) unsafe fn write_wav_to_ptr(
     write_data_to_ptr(output_wav_ptr, output_length_ptr, data);
 }
 
-pub(crate) unsafe fn write_variance_forward_to_ptr(
-    output_variance_forward_pitch_ptr: *mut *mut f32,
-    output_variance_forward_duration_ptr: *mut *mut f32,
-    output_variance_forward_length_ptr: *mut usize,
+pub(crate) unsafe fn write_predict_pitch_and_duration_to_ptr(
+    output_predict_pitch_ptr: *mut *mut f32,
+    output_predict_duration_ptr: *mut *mut f32,
+    output_predict_length_ptr: *mut usize,
     pitch_data: &[f32],
     duration_data: &[f32],
 ) {
     write_data_to_ptr(
-        output_variance_forward_pitch_ptr,
-        output_variance_forward_length_ptr,
+        output_predict_pitch_ptr,
+        output_predict_length_ptr,
         pitch_data,
     );
     write_data_to_ptr(
-        output_variance_forward_duration_ptr,
-        output_variance_forward_length_ptr,
+        output_predict_duration_ptr,
+        output_predict_length_ptr,
         duration_data,
     );
 }

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -40,6 +40,9 @@ pub(crate) fn into_result_code_with_error(result: CApiResult<()>) -> VoicevoxRes
             Err(RustApi(InvalidLengthRegulator { .. })) => {
                 SHAREVOX_RESULT_INVALID_LENGTH_REGULATOR_ERROR
             }
+            Err(RustApi(InvalidSynthesisSystem { .. })) => {
+                SHAREVOX_RESULT_INVALID_SYNTHESIS_SYSTEM_ERROR
+            }
             Err(InvalidUtf8Input) => VOICEVOX_RESULT_INVALID_UTF8_INPUT_ERROR,
             Err(InvalidAudioQuery(_)) => VOICEVOX_RESULT_INVALID_AUDIO_QUERY_ERROR,
         }

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -164,25 +164,25 @@ pub extern "C" fn voicevox_get_supported_devices_json() -> *const c_char {
 /// @param output_predict_duration_data_length uintptr_t 分のメモリ領域が割り当てられていること
 /// @param output_predict_duration_data 成功後にメモリ領域が割り当てられるので ::voicevox_predict_duration_data_free で解放する必要がある
 #[no_mangle]
-pub unsafe extern "C" fn voicevox_variance_forward(
+pub unsafe extern "C" fn voicevox_predict_pitch_and_duration(
     length: usize,
     phoneme_vector: *mut i64,
     accent_vector: *mut i64,
     speaker_id: u32,
-    output_variance_forward_data_length: *mut usize,
-    output_variance_forward_pitch_data: *mut *mut f32,
-    output_variance_forward_duration_data: *mut *mut f32,
+    output_predict_data_length: *mut usize,
+    output_predict_pitch_data: *mut *mut f32,
+    output_predict_duration_data: *mut *mut f32,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
-        let output_vec_pair = lock_internal().variance_forward(
+        let output_vec_pair = lock_internal().predict_pitch_and_duration(
             std::slice::from_raw_parts_mut(phoneme_vector, length),
             std::slice::from_raw_parts_mut(accent_vector, length),
             speaker_id,
         )?;
-        write_variance_forward_to_ptr(
-            output_variance_forward_pitch_data,
-            output_variance_forward_duration_data,
-            output_variance_forward_data_length,
+        write_predict_pitch_and_duration_to_ptr(
+            output_predict_pitch_data,
+            output_predict_duration_data,
+            output_predict_data_length,
             &output_vec_pair.0,
             &output_vec_pair.1,
         );
@@ -196,12 +196,12 @@ pub unsafe extern "C" fn voicevox_variance_forward(
 /// # Safety
 /// @param predict_duration_data 実行後に割り当てられたメモリ領域が解放される
 #[no_mangle]
-pub unsafe extern "C" fn voicevox_variance_forward_data_free(
-    variance_forward_pitch_data: *mut f32,
-    variance_forward_duration_data: *mut f32,
+pub unsafe extern "C" fn voicevox_predict_pitch_and_duration_data_free(
+    predict_pitch_data: *mut f32,
+    predict_duration_data: *mut f32,
 ) {
-    libc::free(variance_forward_pitch_data as *mut c_void);
-    libc::free(variance_forward_duration_data as *mut c_void);
+    libc::free(predict_pitch_data as *mut c_void);
+    libc::free(predict_duration_data as *mut c_void);
 }
 
 /// decodeを実行する
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn voicevox_variance_forward_data_free(
 /// @param output_decode_data_length uintptr_t 分のメモリ領域が割り当てられていること
 /// @param output_decode_data 成功後にメモリ領域が割り当てられるので ::voicevox_decode_data_free で解放する必要がある
 #[no_mangle]
-pub unsafe extern "C" fn voicevox_decode_forward(
+pub unsafe extern "C" fn voicevox_decode(
     length: usize,
     phonemes: *mut i64,
     pitches: *mut f32,
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn voicevox_decode_forward(
     output_decode_data: *mut *mut f32,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
-        let output_vec = lock_internal().decode_forward(
+        let output_vec = lock_internal().decode(
             std::slice::from_raw_parts_mut(phonemes, length),
             std::slice::from_raw_parts_mut(pitches, length),
             std::slice::from_raw_parts_mut(durations, length),

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
@@ -69,7 +69,7 @@ class VoicevoxCore:
         モデルが読み込まれているのであればtrue、そうでないならfalse
         """
         ...
-    def variance_forward(
+    def predict_pitch_and_duration(
         self,
         phoneme_vector: NDArray[np.int64],
         accent_vector: NDArray[np.int64],
@@ -89,7 +89,7 @@ class VoicevoxCore:
         音素ごとの長さ
         """
         ...
-    def decode_forward(
+    def decode(
         self,
         phoneme_vector: NDArray[np.int64],
         pitch_vector: NDArray[np.float32],

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -121,7 +121,7 @@ impl VoicevoxCore {
         self.inner.is_model_loaded(speaker_id)
     }
 
-    fn variance_forward<'py>(
+    fn predict_pitch_and_duration<'py>(
         &mut self,
         phoneme_vector: &'py PyArray<i64, Ix1>,
         accent_vector: &'py PyArray<i64, Ix1>,
@@ -130,7 +130,7 @@ impl VoicevoxCore {
     ) -> VarianceForward<'py> {
         let (pitch, duration) = self
             .inner
-            .variance_forward(
+            .predict_pitch_and_duration(
                 &phoneme_vector.to_vec()?,
                 &accent_vector.to_vec()?,
                 speaker_id,
@@ -142,7 +142,7 @@ impl VoicevoxCore {
         ))
     }
 
-    fn decode_forward<'py>(
+    fn decode<'py>(
         &mut self,
         phoneme_vector: &'py PyArray<i64, Ix1>,
         pitch_vector: &'py PyArray<f32, Ix1>,
@@ -152,7 +152,7 @@ impl VoicevoxCore {
     ) -> PyResult<&'py PyArray<f32, Ix1>> {
         let decoded = self
             .inner
-            .decode_forward(
+            .decode(
                 &phoneme_vector.to_vec()?,
                 &pitch_vector.to_vec()?,
                 &duration_vector.to_vec()?,


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り、VOICEVOXではRust移行に合わせて新しくAPIが用意されたので、そのAPIに合わせて変更を行います。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #3 

