### PR TITLE
[Rust] 関数の名前を変更

### DIFF
--- a/crates/voicevox_core/src/engine/synthesis_engine.rs
+++ b/crates/voicevox_core/src/engine/synthesis_engine.rs
@@ -128,7 +128,7 @@ impl SynthesisEngine {
     ) -> Result<(Vec<AccentPhraseModel>, Vec<f32>)> {
         let (_, phoneme_id_list, accent_id_list) = SynthesisEngine::initial_process(accent_phrases);
 
-        let (pitches, phoneme_length) = self.inference_core_mut().variance_forward(
+        let (pitches, phoneme_length) = self.inference_core_mut().predict_pitch_and_duration(
             &phoneme_id_list,
             &accent_id_list,
             speaker_id,
@@ -194,7 +194,7 @@ impl SynthesisEngine {
         } else {
             pitches = self
                 .inference_core_mut()
-                .variance_forward(&phoneme_id_list, &accent_id_list, speaker_id)?
+                .predict_pitch_and_duration(&phoneme_id_list, &accent_id_list, speaker_id)?
                 .0;
         }
 
@@ -312,7 +312,7 @@ impl SynthesisEngine {
         }
 
         self.inference_core_mut()
-            .decode_forward(&phoneme_id_list, &pitches, &durations, speaker_id)
+            .decode(&phoneme_id_list, &pitches, &durations, speaker_id)
     }
 
     pub fn synthesis_wave_format(

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -114,11 +114,9 @@ impl VoicevoxCore {
         accent_vector: &[i64],
         speaker_id: u32,
     ) -> Result<(Vec<f32>, Vec<f32>)> {
-        self.synthesis_engine.inference_core_mut().predict_pitch_and_duration(
-            phoneme_vector,
-            accent_vector,
-            speaker_id,
-        )
+        self.synthesis_engine
+            .inference_core_mut()
+            .predict_pitch_and_duration(phoneme_vector, accent_vector, speaker_id)
     }
 
     pub fn decode(
@@ -718,10 +716,11 @@ mod tests {
         ];
         let accent_vector = vec![0; phoneme_vector.len()];
 
-        let result = internal
-            .lock()
-            .unwrap()
-            .predict_pitch_and_duration(&phoneme_vector, &accent_vector, 0);
+        let result =
+            internal
+                .lock()
+                .unwrap()
+                .predict_pitch_and_duration(&phoneme_vector, &accent_vector, 0);
 
         assert!(result.is_ok(), "{:?}", result);
 
@@ -790,12 +789,11 @@ mod tests {
         let pitch_vector = vec![5.5; phoneme_vector.len()];
         let duration_vector = vec![0.1; phoneme_vector.len()];
 
-        let result = internal.lock().unwrap().decode(
-            &phoneme_vector,
-            &pitch_vector,
-            &duration_vector,
-            0,
-        );
+        let result =
+            internal
+                .lock()
+                .unwrap()
+                .decode(&phoneme_vector, &pitch_vector, &duration_vector, 0);
 
         assert!(result.is_ok(), "{:?}", result);
         assert_eq!(

--- a/crates/voicevox_core/src/publish.rs
+++ b/crates/voicevox_core/src/publish.rs
@@ -108,27 +108,27 @@ impl VoicevoxCore {
         &SUPPORTED_DEVICES_CSTRING
     }
 
-    pub fn variance_forward(
+    pub fn predict_pitch_and_duration(
         &mut self,
         phoneme_vector: &[i64],
         accent_vector: &[i64],
         speaker_id: u32,
     ) -> Result<(Vec<f32>, Vec<f32>)> {
-        self.synthesis_engine.inference_core_mut().variance_forward(
+        self.synthesis_engine.inference_core_mut().predict_pitch_and_duration(
             phoneme_vector,
             accent_vector,
             speaker_id,
         )
     }
 
-    pub fn decode_forward(
+    pub fn decode(
         &mut self,
         phoneme_vector: &[i64],
         pitch_vector: &[f32],
         duration_vector: &[f32],
         speaker_id: u32,
     ) -> Result<Vec<f32>> {
-        self.synthesis_engine.inference_core_mut().decode_forward(
+        self.synthesis_engine.inference_core_mut().decode(
             phoneme_vector,
             pitch_vector,
             duration_vector,
@@ -323,7 +323,7 @@ impl InferenceCore {
         }
     }
 
-    pub fn variance_forward(
+    pub fn predict_pitch_and_duration(
         &mut self,
         phoneme_vector: &[i64],
         accent_vector: &[i64],
@@ -375,7 +375,7 @@ impl InferenceCore {
         status.variance_session_run(&library_uuid, input_tensors)
     }
 
-    pub fn decode_forward(
+    pub fn decode(
         &mut self,
         phoneme_vector: &[i64],
         pitch_vector: &[f32],
@@ -696,7 +696,7 @@ mod tests {
     // }
 
     #[rstest]
-    fn variance_forward_works() {
+    fn predict_pitch_and_duration_works() {
         let internal = VoicevoxCore::new_with_mutex();
         internal
             .lock()
@@ -721,7 +721,7 @@ mod tests {
         let result = internal
             .lock()
             .unwrap()
-            .variance_forward(&phoneme_vector, &accent_vector, 0);
+            .predict_pitch_and_duration(&phoneme_vector, &accent_vector, 0);
 
         assert!(result.is_ok(), "{:?}", result);
 
@@ -767,7 +767,7 @@ mod tests {
     // }
 
     #[rstest]
-    fn decode_forward_works() {
+    fn decode_works() {
         let internal = VoicevoxCore::new_with_mutex();
         internal
             .lock()
@@ -790,7 +790,7 @@ mod tests {
         let pitch_vector = vec![5.5; phoneme_vector.len()];
         let duration_vector = vec![0.1; phoneme_vector.len()];
 
-        let result = internal.lock().unwrap().decode_forward(
+        let result = internal.lock().unwrap().decode(
             &phoneme_vector,
             &pitch_vector,
             &duration_vector,

--- a/crates/voicevox_core_c_api/src/compatible_engine.rs
+++ b/crates/voicevox_core_c_api/src/compatible_engine.rs
@@ -88,7 +88,7 @@ pub extern "C" fn variance_forward(
     pitch_output: *mut f32,
     duration_output: *mut f32,
 ) -> bool {
-    let result = lock_internal().variance_forward(
+    let result = lock_internal().predict_pitch_and_duration(
         unsafe { std::slice::from_raw_parts_mut(phoneme_list, length as usize) },
         unsafe { std::slice::from_raw_parts_mut(accent_list, length as usize) },
         unsafe { *speaker_id as u32 },
@@ -120,7 +120,7 @@ pub extern "C" fn decode_forward(
     output: *mut f32,
 ) -> bool {
     let length = length as usize;
-    let result = lock_internal().decode_forward(
+    let result = lock_internal().decode(
         unsafe { std::slice::from_raw_parts_mut(phonemes, length) },
         unsafe { std::slice::from_raw_parts_mut(pitches, length) },
         unsafe { std::slice::from_raw_parts_mut(durations, length) },

--- a/crates/voicevox_core_c_api/src/helpers.rs
+++ b/crates/voicevox_core_c_api/src/helpers.rs
@@ -104,21 +104,21 @@ pub(crate) unsafe fn write_wav_to_ptr(
     write_data_to_ptr(output_wav_ptr, output_length_ptr, data);
 }
 
-pub(crate) unsafe fn write_variance_forward_to_ptr(
-    output_variance_forward_pitch_ptr: *mut *mut f32,
-    output_variance_forward_duration_ptr: *mut *mut f32,
-    output_variance_forward_length_ptr: *mut usize,
+pub(crate) unsafe fn write_predict_pitch_and_duration_to_ptr(
+    output_predict_pitch_ptr: *mut *mut f32,
+    output_predict_duration_ptr: *mut *mut f32,
+    output_predict_length_ptr: *mut usize,
     pitch_data: &[f32],
     duration_data: &[f32],
 ) {
     write_data_to_ptr(
-        output_variance_forward_pitch_ptr,
-        output_variance_forward_length_ptr,
+        output_predict_pitch_ptr,
+        output_predict_length_ptr,
         pitch_data,
     );
     write_data_to_ptr(
-        output_variance_forward_duration_ptr,
-        output_variance_forward_length_ptr,
+        output_predict_duration_ptr,
+        output_predict_length_ptr,
         duration_data,
     );
 }

--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -164,25 +164,25 @@ pub extern "C" fn voicevox_get_supported_devices_json() -> *const c_char {
 /// @param output_predict_duration_data_length uintptr_t 分のメモリ領域が割り当てられていること
 /// @param output_predict_duration_data 成功後にメモリ領域が割り当てられるので ::voicevox_predict_duration_data_free で解放する必要がある
 #[no_mangle]
-pub unsafe extern "C" fn voicevox_variance_forward(
+pub unsafe extern "C" fn voicevox_predict_pitch_and_duration(
     length: usize,
     phoneme_vector: *mut i64,
     accent_vector: *mut i64,
     speaker_id: u32,
-    output_variance_forward_data_length: *mut usize,
-    output_variance_forward_pitch_data: *mut *mut f32,
-    output_variance_forward_duration_data: *mut *mut f32,
+    output_predict_data_length: *mut usize,
+    output_predict_pitch_data: *mut *mut f32,
+    output_predict_duration_data: *mut *mut f32,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
-        let output_vec_pair = lock_internal().variance_forward(
+        let output_vec_pair = lock_internal().predict_pitch_and_duration(
             std::slice::from_raw_parts_mut(phoneme_vector, length),
             std::slice::from_raw_parts_mut(accent_vector, length),
             speaker_id,
         )?;
-        write_variance_forward_to_ptr(
-            output_variance_forward_pitch_data,
-            output_variance_forward_duration_data,
-            output_variance_forward_data_length,
+        write_predict_pitch_and_duration_to_ptr(
+            output_predict_pitch_data,
+            output_predict_duration_data,
+            output_predict_data_length,
             &output_vec_pair.0,
             &output_vec_pair.1,
         );
@@ -196,12 +196,12 @@ pub unsafe extern "C" fn voicevox_variance_forward(
 /// # Safety
 /// @param predict_duration_data 実行後に割り当てられたメモリ領域が解放される
 #[no_mangle]
-pub unsafe extern "C" fn voicevox_variance_forward_data_free(
-    variance_forward_pitch_data: *mut f32,
-    variance_forward_duration_data: *mut f32,
+pub unsafe extern "C" fn voicevox_predict_pitch_and_duration_data_free(
+    predict_pitch_data: *mut f32,
+    predict_duration_data: *mut f32,
 ) {
-    libc::free(variance_forward_pitch_data as *mut c_void);
-    libc::free(variance_forward_duration_data as *mut c_void);
+    libc::free(predict_pitch_data as *mut c_void);
+    libc::free(predict_duration_data as *mut c_void);
 }
 
 /// decodeを実行する
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn voicevox_variance_forward_data_free(
 /// @param output_decode_data_length uintptr_t 分のメモリ領域が割り当てられていること
 /// @param output_decode_data 成功後にメモリ領域が割り当てられるので ::voicevox_decode_data_free で解放する必要がある
 #[no_mangle]
-pub unsafe extern "C" fn voicevox_decode_forward(
+pub unsafe extern "C" fn voicevox_decode(
     length: usize,
     phonemes: *mut i64,
     pitches: *mut f32,
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn voicevox_decode_forward(
     output_decode_data: *mut *mut f32,
 ) -> VoicevoxResultCode {
     into_result_code_with_error((|| {
-        let output_vec = lock_internal().decode_forward(
+        let output_vec = lock_internal().decode(
             std::slice::from_raw_parts_mut(phonemes, length),
             std::slice::from_raw_parts_mut(pitches, length),
             std::slice::from_raw_parts_mut(durations, length),

--- a/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
+++ b/crates/voicevox_core_python_api/python/voicevox_core/_rust.pyi
@@ -69,7 +69,7 @@ class VoicevoxCore:
         モデルが読み込まれているのであればtrue、そうでないならfalse
         """
         ...
-    def variance_forward(
+    def predict_pitch_and_duration(
         self,
         phoneme_vector: NDArray[np.int64],
         accent_vector: NDArray[np.int64],
@@ -89,7 +89,7 @@ class VoicevoxCore:
         音素ごとの長さ
         """
         ...
-    def decode_forward(
+    def decode(
         self,
         phoneme_vector: NDArray[np.int64],
         pitch_vector: NDArray[np.float32],

--- a/crates/voicevox_core_python_api/src/lib.rs
+++ b/crates/voicevox_core_python_api/src/lib.rs
@@ -121,7 +121,7 @@ impl VoicevoxCore {
         self.inner.is_model_loaded(speaker_id)
     }
 
-    fn variance_forward<'py>(
+    fn predict_pitch_and_duration<'py>(
         &mut self,
         phoneme_vector: &'py PyArray<i64, Ix1>,
         accent_vector: &'py PyArray<i64, Ix1>,
@@ -130,7 +130,7 @@ impl VoicevoxCore {
     ) -> VarianceForward<'py> {
         let (pitch, duration) = self
             .inner
-            .variance_forward(
+            .predict_pitch_and_duration(
                 &phoneme_vector.to_vec()?,
                 &accent_vector.to_vec()?,
                 speaker_id,
@@ -142,7 +142,7 @@ impl VoicevoxCore {
         ))
     }
 
-    fn decode_forward<'py>(
+    fn decode<'py>(
         &mut self,
         phoneme_vector: &'py PyArray<i64, Ix1>,
         pitch_vector: &'py PyArray<f32, Ix1>,
@@ -152,7 +152,7 @@ impl VoicevoxCore {
     ) -> PyResult<&'py PyArray<f32, Ix1>> {
         let decoded = self
             .inner
-            .decode_forward(
+            .decode(
                 &phoneme_vector.to_vec()?,
                 &pitch_vector.to_vec()?,
                 &duration_vector.to_vec()?,


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り、VOICEVOXではRust移行に合わせて新しくAPIが用意されたので、そのAPIに合わせて変更を行います。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #3 
