### PR TITLE
デフォルトの`tracing_subscriber::EnvFilter`を修正

### DIFF
--- a/crates/voicevox_core_c_api/src/lib.rs
+++ b/crates/voicevox_core_c_api/src/lib.rs
@@ -24,7 +24,7 @@ static INTERNAL: Lazy<Mutex<Internal>> = Lazy::new(|| {
         .with_env_filter(if env::var_os(EnvFilter::DEFAULT_ENV).is_some() {
             EnvFilter::from_default_env()
         } else {
-            "error,sharevox_core=info,sharevox_core_c_api=info,onnxruntime=info".into()
+            "error,voicevox_core=info,sharevox_core_c_api=info,onnxruntime=info".into()
         })
         .with_writer(io::stderr)
         .try_init();


### PR DESCRIPTION
## 内容

Rust APIクレートの名前が`voicevox_core`のままにも関わらず、デフォルトの[`tracing_subscriber::EnvFilter`](https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/struct.EnvFilter.html)ではリネームしてしまっているため、そこだけ元に戻します。

## 関連 Issue

## その他
